### PR TITLE
wilc3000-fw_15.2.bb: Add recipe for Microchip WILC3000 firmware

### DIFF
--- a/Ultra96/petalinux_bsp_v2/meta-user/conf/layer.conf
+++ b/Ultra96/petalinux_bsp_v2/meta-user/conf/layer.conf
@@ -1,0 +1,11 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-user"
+BBFILE_PATTERN_meta-user = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-user = "6"
+LAYERSERIES_COMPAT_meta-user = "thud"

--- a/Ultra96/petalinux_bsp_v2/meta-user/conf/petalinuxbsp.conf
+++ b/Ultra96/petalinux_bsp_v2/meta-user/conf/petalinuxbsp.conf
@@ -1,0 +1,28 @@
+#User Configuration
+
+#OE_TERMINAL = "tmux"
+
+# Add EXTRA_IMAGEDEPENDS default components
+EXTRA_IMAGEDEPENDS_append_versal = " virtual/psm-firmware virtual/plm arm-trusted-firmware u-boot-zynq-scr"
+EXTRA_IMAGEDEPENDS_append_zynqmp = " virtual/fsbl virtual/pmu-firmware arm-trusted-firmware"
+EXTRA_IMAGEDEPENDS_append_zynq = " virtual/fsbl"
+EXTRA_IMAGEDEPENDS_append_microblaze = " virtual/fsboot virtual/elfrealloc"
+
+# prevent U-Boot from deploying the boot.bin
+SPL_BINARY = ""
+
+#Remove all qemu contents
+IMAGE_CLASSES_remove = "image-types-xilinx-qemu qemuboot-xilinx"
+IMAGE_FSTYPES_remove = "wic.qemu-sd"
+
+EXTRA_IMAGEDEPENDS_remove = "qemu-helper-native virtual/boot-bin"
+SIGGEN_UNLOCKED_RECIPES_append_versal = " initscripts"
+
+MACHINE_FEATURES_remove_ultra96-zynqmp = "mipi"
+
+# Auto load wilc_sdio module for Ultra96-V2 board
+KERNEL_MODULE_AUTOLOAD += "wilc_sdio"
+
+# Remove TI WL18xx firmware for Ultra96-V2 board
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS_remove = "linux-firmware-wl18xx"
+

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-bsp/wilc3000-fw/wilc3000-fw_15.2.bb
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-bsp/wilc3000-fw/wilc3000-fw_15.2.bb
@@ -1,0 +1,22 @@
+HOMEPAGE = "https://github.com/linux4wilc/firmware"
+DESCRIPTION = "Firmware files for use with Microchip wilc3000"
+LICENSE = "CLOSED"
+LIC_FILES_CHKSUM = "file://LICENCE.wilc_fw;md5=89ed0ff0e98ce1c58747e9a39183cc9f"
+
+SRC_URI = "git://github.com/linux4wilc/firmware.git;protocol=git;branch=${BRANCH}"
+
+# Tag: wilc_linux_15_2_1
+SRCREV = "699c2f18fed78355e5b7ef0518222e53ede3b9e0"
+BRANCH = "master"
+
+S = "${WORKDIR}/git"
+
+# Depends on Wilc driver https://github.com/Avnet/u96v2-wilc-driver
+DEPENDS += "wilc"
+
+do_install() {
+    install -d ${D}${base_libdir}/firmware/mchp
+    install -m 0755 ${S}/wilc* ${D}${base_libdir}/firmware/mchp
+}
+
+FILES_${PN} = "${base_libdir}/firmware/mchp/*"

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/images/petalinux-image-full.bbappend
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/images/petalinux-image-full.bbappend
@@ -1,0 +1,16 @@
+#Note: Mention Each package in individual line
+#      cascaded representation with line breaks are not valid in this file.
+IMAGE_INSTALL_append = " peekpoke"
+IMAGE_INSTALL_append = " gpio-demo"
+IMAGE_INSTALL_append = " packagegroup-base-extended"
+IMAGE_INSTALL_append = " cmake"
+IMAGE_INSTALL_append = " lmsensors-sensorsdetect"
+IMAGE_INSTALL_append = " python-pyserial"
+IMAGE_INSTALL_append = " libftdi"
+IMAGE_INSTALL_append = " python3-pip"
+IMAGE_INSTALL_append = " iperf3"
+IMAGE_INSTALL_append = " packagegroup-petalinux-ultra96-webapp"
+IMAGE_INSTALL_append = " packagegroup-petalinux-96boards-sensors"
+IMAGE_INSTALL_append = " ultra96-ap-setup"
+IMAGE_INSTALL_append = " wilc"
+IMAGE_INSTALL_append = " wilc3000-fw"

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/images/petalinux-user-image.bbappend
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/images/petalinux-user-image.bbappend
@@ -1,0 +1,8 @@
+# Auto load wilc_sdio module during kernel boot
+rootfs_postprocess_function() {
+    echo "wilc_sdio" > ${IMAGE_ROOTFS}/etc/modules-load.d/wilc_sdio.conf
+}
+
+ROOTFS_POSTPROCESS_COMMAND_append = " \
+    rootfs_postprocess_function; \
+"

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/init-ifupdown/files/interfaces
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/init-ifupdown/files/interfaces
@@ -1,0 +1,32 @@
+# /etc/network/interfaces -- configuration file for ifup(8), ifdown(8)
+ 
+# The loopback interface
+auto lo
+iface lo inet loopback
+
+# Wireless interfaces
+auto wlan0
+iface wlan0 inet dhcp
+	wireless_mode managed
+	wireless_essid any
+	wpa-driver wext
+	wpa-conf /etc/wpa_supplicant.conf
+
+iface atml0 inet dhcp
+
+# Wired or wireless interfaces
+auto eth0
+iface eth0 inet dhcp
+iface eth1 inet dhcp
+
+# Ethernet/RNDIS gadget (g_ether)
+# ... or on host side, usbnet and random hwaddr
+iface usb0 inet static
+	address 192.168.7.2
+	netmask 255.255.255.0
+	network 192.168.7.0
+	gateway 192.168.7.1
+
+# Bluetooth networking
+iface bnep0 inet dhcp
+

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/init-ifupdown/init-ifupdown_%.bbappend
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-core/init-ifupdown/init-ifupdown_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"


### PR DESCRIPTION
Added new recipe for Micochip WILC3000 firmware. This recipe depends on
wilc driver https://github.com/Avnet/u96v2-wilc-driver/tree/v15_2

Signed-off-by: Sandeep Gundlupet Raju <grsandeep85@gmail.com>