### PR TITLE
Add support for power monitoring to the V2

### DIFF
--- a/Ultra96/packages/sensorconf/ultra96.conf
+++ b/Ultra96/packages/sensorconf/ultra96.conf
@@ -1,4 +1,55 @@
 bus "i2c-7" "i2c-1-mux (chan_id 5)"
+bus "i2c-6" "i2c-0-mux (chan_id 4)"
+
+chip "*-i2c-6-43"
+        ignore in1
+        ignore power1
+        ignore curr1
+        label in2 "AUX"
+        label in3 "1V2"
+        label in4 "PSDDR"
+        label in5 "INT"
+        label in6 "3V3_D"
+        label power2 "AUX"
+        label power3 "1V2"
+        label power4 "PSDDR"
+        label power5 "INT"
+        label power6 "3V3_D"
+        label curr2 "AUX"
+        label curr3 "1V2"
+        label curr4 "PSDDR"
+        label curr5 "INT"
+        label curr6 "3V3_D"
+
+
+chip "*-i2c-6-44"
+        ignore in1
+        ignore power1
+        ignore curr1
+        label in2 "PSAUX"
+        label in3 "PSINT_LP"
+        label in4 "3V3"
+        label in5 "PSINT_FP"
+        label in6 "PSPLL"
+        label power2 "PSAUX"
+        label power3 "PSINT_LP"
+        label power4 "3V3"
+        label power5 "PSINT_FP"
+        label power6 "PSPLL"
+        label curr2 "PSAUX"
+        label curr3 "PSINT_LP"
+        label curr4 "3V3"
+        label curr5 "PSINT_FP"
+        label curr6 "PSPLL"
+
+chip "*-i2c-6-45"
+        #ignore power1
+        label in1 "VIN"
+        label curr1 "5V"
+        label power1 "5V"
+        label in2 "5V"
+        compute in2 @/256,@*256
+
 
 chip "*-i2c-7-40"
 	label in1 "VSYS"

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-bsp/device-tree/files/system-user.dtsi
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-bsp/device-tree/files/system-user.dtsi
@@ -57,3 +57,18 @@
         };
 };
 
+&i2csw_4 {
+	/delete-node/ pmic@5e;
+	pmic1: pmic@43 {
+		reg = <0x43>;
+		compatible = "infineon,irps5401";
+	};
+	pmic2: pmic@44 {
+		reg = <0x44>;
+		compatible = "infineon,irps5401";
+	};
+	pmic3: pmic@45 {
+		reg = <0x45>;
+		compatible = "infineon,ir38060";
+	};
+};

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-kernel/linux/linux-xlnx/0001-irps5401.patch
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-kernel/linux/linux-xlnx/0001-irps5401.patch
@@ -1,0 +1,25 @@
+From 13784efbd81b83bb242484f13958ee72983af023 Mon Sep 17 00:00:00 2001
+From: Rock Qu <yunq@xilinx.com>
+Date: Thu, 23 May 2019 11:34:58 -0700
+Subject: [PATCH 1/2] irps5401
+
+---
+ drivers/hwmon/pmbus/pmbus.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/hwmon/pmbus/pmbus.c b/drivers/hwmon/pmbus/pmbus.c
+index be00cd1..fe6b4eb 100644
+--- a/drivers/hwmon/pmbus/pmbus.c
++++ b/drivers/hwmon/pmbus/pmbus.c
+@@ -215,6 +215,8 @@ static int pmbus_probe(struct i2c_client *client,
+ 	{"tps544c20", 1},
+ 	{"tps544c25", 1},
+ 	{"udt020", 1},
++	{"irps5401", 5},
++	{"ir38060", 1},
+ 	{}
+ };
+ 
+-- 
+1.9.5
+

--- a/Ultra96/petalinux_bsp_v2/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/Ultra96/petalinux_bsp_v2/meta-user/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -1,5 +1,6 @@
 SRC_URI += "file://bsp.cfg"
 
 SRC_URI_append = " file://fix_u96v2_pwrseq_simple.patch"
+SRC_URI_append = " file://0001-irps5401.patch"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
This commits adds everything needed to get `pynq.pmbus` fully working on the Ultra96v2.

 * Patch kernel to add support for infineon chips used on the Ultra96v2
 * Add entries for PMICs in device-tree
 * Add libsensors configuration to name rails according to schematic