### PR TITLE
Update link from 'zedboard' site to 'Avnet' site.

### DIFF
--- a/docs/source/for_more_information.rst
+++ b/docs/source/for_more_information.rst
@@ -12,7 +12,7 @@ PYNQ
 
 Ultra96
 =======
-* http://zedboard.org/product/ultra96
+* https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/ultra96-v2/
 * https://www.96boards.org/product/ultra96
 * https://www.xilinx.com/products/boards-and-kits/1-vad4rl.html
 


### PR DESCRIPTION
Link to zedboard.org does not exist anymore and should be replaced by a working link.